### PR TITLE
[DV-53] ProgressBar 컴포넌트 구현하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.0.1",
         "react": "19.0.0-rc-69d4b800-20241021",
-        "react-dom": "19.0.0-rc-69d4b800-20241021"
+        "react-dom": "19.0.0-rc-69d4b800-20241021",
+        "react-icons": "^5.3.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4161,6 +4162,14 @@
       },
       "peerDependencies": {
         "react": "19.0.0-rc-69d4b800-20241021"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.0.1",
     "react": "19.0.0-rc-69d4b800-20241021",
     "react-dom": "19.0.0-rc-69d4b800-20241021",
-    "next": "15.0.1"
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "15.0.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "15.0.1"
+    "typescript": "^5"
   }
 }

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -5,10 +5,10 @@ const InterviewPage = () => {
   return (
     <div>
       <div className="flex gap-4">
-        <Link href={"/interview/setup"} className="border px-4 py-2">
+        <Link href={"/interview/setup?type=mock"} className="border px-4 py-2">
           모의면접
         </Link>
-        <Link href={"/interview/setup"} className="border px-4 py-2">
+        <Link href={"/interview/setup?type=real"} className="border px-4 py-2">
           실전면접
         </Link>
       </div>

--- a/src/app/interview/setup/page.tsx
+++ b/src/app/interview/setup/page.tsx
@@ -4,35 +4,44 @@ import { useRouter, useSearchParams } from "next/navigation";
 import SetupFunnel from "@/components/interview/setup-funnel";
 import SetupProgressBar from "@/components/interview/setup-progress-bar";
 
+type StepType = "type" | "method" | "job" | "cover-letter" | "check-info";
+
 const InterviewSetupPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const interviewMode = (searchParams.get("type") as "mock" | "real") || "real";
   const [currentStep, setCurrentStep] = useState<StepType>("type");
+
+  const steps: StepType[] =
+    interviewMode === "mock"
+      ? ["type", "method", "job", "check-info"]
+      : ["type", "method", "job", "cover-letter", "check-info"];
 
   useEffect(() => {
     const step = searchParams.get("step") as StepType;
     if (!step) {
-      router.replace(`/interview/setup?step=type`);
+      router.replace(`/interview/setup?type=${interviewMode}&step=type`);
     } else {
       setCurrentStep(step);
     }
-  }, [searchParams, router]);
+  }, [searchParams, router, interviewMode]);
 
   const updateStep = (newStep: StepType) => {
     setCurrentStep(newStep);
-    router.push(`/interview/setup?step=${newStep}`);
+    router.push(`/interview/setup?type=${interviewMode}&step=${newStep}`);
   };
 
   return (
     <>
       <div className="pb-10 px-8">
-        <SetupProgressBar
-          steps={["type", "method", "job", "cover-letter", "check-info"]}
-          currentStep={currentStep}
-        />
+        <SetupProgressBar steps={steps} currentStep={currentStep} />
       </div>
       <div className="relative w-[200px] h-[200px]">
-        <SetupFunnel step={currentStep} setStep={updateStep} />
+        <SetupFunnel
+          step={currentStep}
+          setStep={updateStep}
+          interviewMode={interviewMode}
+        />
       </div>
     </>
   );

--- a/src/components/interview/setup-funnel.tsx
+++ b/src/components/interview/setup-funnel.tsx
@@ -57,16 +57,14 @@ const SetupFunnel = ({ step, setStep, interviewMode }: SetupFunnelProps) => {
         />
       </Funnel.Step>
       <Funnel.Step name="cover-letter">
-        {interviewMode === "real" && (
-          <CoverLetterStep
-            onPrev={() => {
-              setStep("job");
-            }}
-            onNext={() => {
-              setStep("check-info");
-            }}
-          />
-        )}
+        <CoverLetterStep
+          onPrev={() => {
+            setStep("job");
+          }}
+          onNext={() => {
+            setStep("check-info");
+          }}
+        />
       </Funnel.Step>
       <Funnel.Step name="check-info">
         <CheckInfoStep

--- a/src/components/interview/setup-funnel.tsx
+++ b/src/components/interview/setup-funnel.tsx
@@ -7,19 +7,24 @@ import CoverLetterStep from "./step/cover-letter-step";
 import CheckInfoStep from "./step/check-info-step";
 import { Funnel } from "../funnel";
 
+type StepType = "type" | "method" | "job" | "cover-letter" | "check-info";
+
 interface SetupFunnelProps {
   step: StepType;
   setStep: (step: StepType) => void;
+  interviewMode: "mock" | "real";
 }
 
-const SetupFunnel = ({ step, setStep }: SetupFunnelProps) => {
+const SetupFunnel = ({ step, setStep, interviewMode }: SetupFunnelProps) => {
   const router = useRouter();
 
+  const steps =
+    interviewMode === "mock"
+      ? (["type", "method", "job", "check-info"] as const)
+      : (["type", "method", "job", "cover-letter", "check-info"] as const);
+
   return (
-    <Funnel
-      steps={["type", "method", "job", "cover-letter", "check-info"]}
-      step={step}
-    >
+    <Funnel steps={steps} step={step}>
       <Funnel.Step name="type">
         <TypeStep
           onPrev={() => {
@@ -47,24 +52,26 @@ const SetupFunnel = ({ step, setStep }: SetupFunnelProps) => {
             setStep("method");
           }}
           onNext={() => {
-            setStep("cover-letter");
+            setStep(interviewMode === "mock" ? "check-info" : "cover-letter");
           }}
         />
       </Funnel.Step>
       <Funnel.Step name="cover-letter">
-        <CoverLetterStep
-          onPrev={() => {
-            setStep("job");
-          }}
-          onNext={() => {
-            setStep("check-info");
-          }}
-        />
+        {interviewMode === "real" && (
+          <CoverLetterStep
+            onPrev={() => {
+              setStep("job");
+            }}
+            onNext={() => {
+              setStep("check-info");
+            }}
+          />
+        )}
       </Funnel.Step>
       <Funnel.Step name="check-info">
         <CheckInfoStep
           onPrev={() => {
-            setStep("cover-letter");
+            setStep(interviewMode === "mock" ? "job" : "cover-letter");
           }}
           onNext={() => {
             setStep("check-info");

--- a/src/components/interview/setup-progress-bar.tsx
+++ b/src/components/interview/setup-progress-bar.tsx
@@ -1,3 +1,5 @@
+import { FaCheck } from "react-icons/fa"; // 체크 아이콘을 위한 import
+
 interface SetupProgressBarProps {
   steps: StepType[];
   currentStep: StepType;
@@ -9,8 +11,8 @@ export default function SetupProgressBar({
 }: SetupProgressBarProps) {
   const currentStepIndex = steps.indexOf(currentStep);
 
-  const getStepLabel = (step: StepType): StepLabel<typeof step> => {
-    const labels: StepLabels = {
+  const getStepLabel = (step: StepType) => {
+    const labels = {
       type: "면접 유형",
       method: "면접 방식",
       job: "직무 선택",
@@ -27,25 +29,35 @@ export default function SetupProgressBar({
           <div className="flex items-center">
             <div className="relative">
               <div
-                className={`w-8 h-8 flex items-center justify-center rounded-full ${
-                  index <= currentStepIndex
+                className={`w-8 h-8 flex items-center justify-center rounded-full transition-all duration-300 ${
+                  index < currentStepIndex
                     ? "bg-secondary text-white"
-                    : "bg-gray-300"
+                    : index === currentStepIndex
+                    ? "bg-white border-4 border-secondary"
+                    : "border-4 border-gray-300 text-gray-500"
                 }`}
               >
-                {index + 1}
+                {index < currentStepIndex ? (
+                  <FaCheck size={12} />
+                ) : index === currentStepIndex ? (
+                  <div className="w-2 h-2 bg-secondary rounded-full"></div>
+                ) : null}{" "}
               </div>
-              <div className="absolute top-10 left-1/2 -translate-x-1/2 w-28 text-center">
+              <div className="absolute top-10 left-1/2 -translate-x-1/2 w-28 text-center text-sm font-bold">
                 {getStepLabel(step)}
               </div>
             </div>
 
             {index < steps.length - 1 && (
-              <div
-                className={`h-1 w-20 ${
-                  index < currentStepIndex ? "bg-secondary" : "bg-gray-300"
-                }`}
-              ></div>
+              <div className="relative w-48 h-1">
+                <div className="absolute top-0 left-0 w-full h-full bg-gray-300"></div>
+                <div
+                  className={`absolute top-0 left-0 h-full bg-secondary transition-all duration-500 ease-out`}
+                  style={{
+                    width: index < currentStepIndex ? "100%" : "0%",
+                  }}
+                ></div>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/interview/step/type-step.tsx
+++ b/src/components/interview/step/type-step.tsx
@@ -11,7 +11,7 @@ const TypeStep = ({ onPrev, onNext }: StepProps) => {
       <NavButtons
         onPrev={onPrev}
         onNext={onNext}
-        prevButtonText="홈으로"
+        prevButtonText="이전"
         nextButtonText="다음"
       />
     </>


### PR DESCRIPTION
## 제목 형식

- DV-53 프로그레스바 구현하기

## PR 설명

- 이 PR에서 해결하려는 문제는 무엇인가요?
  - 모의면접, 실전면접 선택에 따라 다른 구성의 프로그레스바가 연결되도록 해야 합니다.
  - 프로그레스바 디자인을 해야 합니다.
- 이 PR을 통해 추가된 기능이나 변경사항은 무엇인가요?
  - 모의/실전에 따라 4단계/5단계로 구성된 프로그레스바로 연결됩니다.
  - 입력완료/입력중/입력전 3단계로 나누어서 label이 표시되도록 하였습니다.
  - 다음단계로 넘어갈때 프로그레스바가 자연스럽게 채워지도록 하였습니다.

## 주요 변경 사항

- [x]  모의/실전 선택에 따라 다른 프로그레스바 불러오기
- [x] 입력완료는 체크, 입력중은 동그라미, 입력전은 비어있는 동그라미가 보이도록 디자인 변경
- [x] 단계가 진행되는 모습을 자연스럽게 보여지도록 하기 위해 다음 단계 넘어갈 때 왼쪽부터 오른쪽으로 채워지도록 디자인 변경


## 스크린샷 (변경 사항이 UI에 영향을 미칠 경우)
- 모의면접 클릭시
![image](https://github.com/user-attachments/assets/3bb7dab0-5ee6-412d-a3da-ae86e23c75d1)
- 실전면접 클릭시
![image](https://github.com/user-attachments/assets/a2995c4f-c6a0-45fb-9bd7-3d4e79f547f2)

- 진행상태에 따라 프로그레스바 라벨 디자인 변경
![image](https://github.com/user-attachments/assets/190e9f51-b13b-401d-b411-5d58e05f63b0)

