### PR TITLE
[DV-54] SettingBtn 컴포넌트 구현하기

### DIFF
--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -1,15 +1,37 @@
+"use client";
+import { useState } from "react";
 import Link from "next/link";
-import React from "react";
+import SettingBtn from "@/components/settingbtn";
 
 const InterviewPage = () => {
+  const [mode, setMode] = useState("mock");
+
   return (
-    <div>
+    <div className="flex flex-col items-center gap-6">
       <div className="flex gap-4">
-        <Link href={"/interview/setup?type=mock"} className="border px-4 py-2">
-          모의면접
+        <SettingBtn
+          label="모의면접"
+          description="선택한 관심 직무를 기반으로 가상면접을 진행합니다."
+          selected={mode === "mock"}
+          onClick={() => setMode("mock")}
+        />
+        <SettingBtn
+          label="실전면접"
+          description="선택한 직무와 자소서, 이력서 등을 기반으로 개인 맞춤화 가상면접을 진행합니다."
+          selected={mode === "real"}
+          onClick={() => setMode("real")}
+        />
+      </div>
+      <div className="flex gap-4 mt-8 font-semibold">
+        <Link href="/">
+          <button className="bg-secondary text-white py-2 px-6 rounded-md">
+            홈으로
+          </button>
         </Link>
-        <Link href={"/interview/setup?type=real"} className="border px-4 py-2">
-          실전면접
+        <Link href={`/interview/setup?type=${mode}`}>
+          <button className="bg-secondary text-white py-2 px-6 rounded-md">
+            다음
+          </button>
         </Link>
       </div>
     </div>

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -8,7 +8,7 @@ const InterviewPage = () => {
 
   return (
     <div className="flex flex-col items-center gap-6">
-      <div className="flex gap-4">
+      <div className="flex gap-16">
         <SettingBtn
           label="모의면접"
           description="선택한 관심 직무를 기반으로 가상면접을 진행합니다."
@@ -24,12 +24,12 @@ const InterviewPage = () => {
       </div>
       <div className="flex gap-4 mt-8 font-semibold">
         <Link href="/">
-          <button className="bg-secondary text-white py-2 px-6 rounded-md">
+          <button className="bg-secondary w-24 text-white py-2 px-6 rounded-md">
             홈으로
           </button>
         </Link>
         <Link href={`/interview/setup?type=${mode}`}>
-          <button className="bg-secondary text-white py-2 px-6 rounded-md">
+          <button className="bg-secondary w-24 text-white py-2 px-6 rounded-md">
             다음
           </button>
         </Link>

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -1,3 +1,33 @@
-export default function SettingBtn() {
-  return <div>모드/유형/방법 선택 버튼 컴포넌트</div>;
-}
+"use client";
+import { useState } from "react";
+
+type ButtonProps = {
+  label: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+};
+
+const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div
+      className={`border rounded-lg p-6 text-center cursor-pointer transition-all duration-200 ${
+        selected ? "bg-primary text-white" : "bg-gray-200 text-black"
+      } ${isHovered ? "h-32" : "h-24"}`}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="font-bold text-lg">{label}</div>
+      {isHovered && (
+        <div className="mt-2 text-sm text-black bg-white p-2 rounded-md shadow-md">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SettingBtn;

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -10,6 +10,7 @@ type ButtonProps = {
 
 const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
   const [isHovered, setIsHovered] = useState(false);
+  const descriptionWords = description.split(" ");
 
   return (
     <div
@@ -28,15 +29,18 @@ const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
         {label}
       </div>
 
-      {/* 설명 영역 */}
-      {isHovered && (
-        <div
-          className="absolute bottom-4 text-sm text-black bg-white p-3 rounded-md shadow-md transition-opacity duration-300 opacity-100"
-          style={{ width: "90%" }}
-        >
-          {description}
-        </div>
-      )}
+      <div
+        className={`absolute bottom-6 text-base font-medium text-black bg-white bg-opacity-90 p-5 rounded-lg shadow-lg transition-all duration-500 transform ${
+          isHovered ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+        }`}
+        style={{ width: "90%", minHeight: "4rem" }}
+      >
+        {descriptionWords.map((word, index) => (
+          <span key={index} className="inline-block mr-1">
+            {word}
+          </span>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -13,16 +13,27 @@ const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
 
   return (
     <div
-      className={`border rounded-lg p-6 text-center cursor-pointer transition-all duration-200 ${
+      className={`relative border rounded-3xl w-[400px] h-[300px] flex items-center justify-center text-center cursor-pointer transition-all duration-300 ${
         selected ? "bg-primary text-white" : "bg-gray-200 text-black"
-      } ${isHovered ? "h-32" : "h-24"}`}
+      }`}
       onClick={onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="font-bold text-lg">{label}</div>
+      <div
+        className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
+          isHovered ? "-translate-y-2" : ""
+        }`}
+      >
+        {label}
+      </div>
+
+      {/* 설명 영역 */}
       {isHovered && (
-        <div className="mt-2 text-sm text-black bg-white p-2 rounded-md shadow-md">
+        <div
+          className="absolute bottom-4 text-sm text-black bg-white p-3 rounded-md shadow-md transition-opacity duration-300 opacity-100"
+          style={{ width: "90%" }}
+        >
           {description}
         </div>
       )}


### PR DESCRIPTION
## [DV-54] 면접 선택 버튼 컴포넌트 구현하기

## PR 설명

- 이 PR에서 해결하려는 문제는 무엇인가요?
  - 면접모드, 유형, 방식 선택 시 사용되는 버튼 컴포넌트를 구현합니다.
- 이 PR을 통해 추가된 기능이나 변경사항은 무엇인가요?
  - 세팅버튼 컴포넌트를 구현했습니다.
  - 모드 선택 창에 홈으로와 다음 버튼이 추가되었습니다.
## 주요 변경 사항

- [x] 면접 모드 선택 페이지에서 세팅버튼 컴포넌트 확인하기
- [x] 마우스 호버 시 해당 모드에 대한 설명 보여주기 
- [x] 홈으로, 다음 버튼 추가하기

## 스크린샷 (변경 사항이 UI에 영향을 미칠 경우)
- 호버 전
![image](https://github.com/user-attachments/assets/fb79aac5-2eca-4fb3-bbe6-63c64aba86e1)
- 호버 후
![image](https://github.com/user-attachments/assets/2f45e5f6-a403-4aa1-a2cd-79008799bd3a)



[DV-54]: https://richardstallman.atlassian.net/browse/DV-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ