### PR TITLE
[DV-60] 면접 setup 페이지 UI 구현

### DIFF
--- a/src/app/interview/layout.tsx
+++ b/src/app/interview/layout.tsx
@@ -9,7 +9,7 @@ const InterviewLayout = ({ children }: InterviewLayoutProps) => {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="relative flex-1 flex flex-col items-center justify-start">
+      <main className="relative flex-1 flex flex-col items-center justify-center">
         {children}
       </main>
       <Footer />

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -8,6 +8,10 @@ const InterviewPage = () => {
 
   return (
     <div className="flex flex-col items-center gap-6">
+      <div className="text-center text-[50px] font-bold mb-16">
+        면접 모드 선택
+      </div>
+
       <div className="flex gap-16">
         <SettingBtn
           label="모의면접"
@@ -22,6 +26,7 @@ const InterviewPage = () => {
           onClick={() => setMode("real")}
         />
       </div>
+
       <div className="flex gap-4 mt-8 font-semibold">
         <Link href="/">
           <button className="bg-secondary w-24 text-white py-2 px-6 rounded-md">

--- a/src/app/interview/setup/page.tsx
+++ b/src/app/interview/setup/page.tsx
@@ -50,7 +50,7 @@ const InterviewSetupPage = () => {
       <div className="pb-10 px-8 mb-8">
         <SetupProgressBar steps={steps} currentStep={currentStep} />
       </div>
-      <div className="relative w-[200px] h-[200px]">
+      <div className="flex flex-col items-center gap-8">
         <SetupFunnel
           step={currentStep}
           setStep={updateStep}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,8 +3,7 @@ import Image from "next/image";
 
 export default function Header() {
   return (
-    <header className="flex h-16 justify-between items-center px-8 border-b mb-24">
-
+    <header className="flex h-16 justify-between items-center px-8 border-b">
       <Link href="/">
         <div className="relative w-[72.2px] h-[40px]">
           <Image

--- a/src/components/interview/step/check-info-step.tsx
+++ b/src/components/interview/step/check-info-step.tsx
@@ -4,9 +4,22 @@ import NavButtons from "./nav-button";
 const CheckInfoStep = ({ onPrev, onNext }: StepProps) => {
   return (
     <>
-      <div>
-        <button>입력 정보 확인</button>
+      <div className="flex justify-center mb-8">
+        <div className="font-semibold border-2 border-secondary w-[900px] h-[300px] p-6 rounded-lg text-center">
+          <p className="mb-2">면접 모드: ~~</p>
+          <p className="mb-2">면접 유형: ~~</p>
+          <p className="mb-2">면접 방식: ~~</p>
+          <p className="mb-2">선택 직무: ~~</p>
+          <p className="mb-4">자기소개서: ~~</p>
+          <p className="font-bold text-lg mt-10">
+            위 정보가 맞는지 확인해주세요.
+          </p>
+          <p className="text-gray-600">
+            질문이 생성된 이후에는 이용권 환불이 불가합니다.
+          </p>
+        </div>
       </div>
+
       <NavButtons
         onPrev={onPrev}
         onNext={onNext}

--- a/src/components/interview/step/cover-letter-step.tsx
+++ b/src/components/interview/step/cover-letter-step.tsx
@@ -9,7 +9,7 @@ const CoverLetterStep = ({ onPrev, onNext }: StepProps) => {
   };
 
   return (
-    <div className="flex flex-col items-center gap-8">
+    <>
       <div className="flex justify-center w-screen">
         <textarea
           value={coverLetter}
@@ -24,7 +24,7 @@ const CoverLetterStep = ({ onPrev, onNext }: StepProps) => {
         prevButtonText="이전"
         nextButtonText="다음"
       />
-    </div>
+    </>
   );
 };
 

--- a/src/components/interview/step/job-step.tsx
+++ b/src/components/interview/step/job-step.tsx
@@ -13,7 +13,7 @@ const JobStep = ({ onPrev, onNext }: StepProps) => {
   ];
 
   return (
-    <div className="flex flex-col items-center gap-8">
+    <>
       <div className="flex gap-4 justify-center">
         {jobs.map((job) => (
           <PositionBtn
@@ -31,7 +31,7 @@ const JobStep = ({ onPrev, onNext }: StepProps) => {
         prevButtonText="이전"
         nextButtonText="다음"
       />
-    </div>
+    </>
   );
 };
 

--- a/src/components/interview/step/method-step.tsx
+++ b/src/components/interview/step/method-step.tsx
@@ -16,15 +16,17 @@ const MethodStep = ({ onPrev, onNext }: StepProps) => {
         />
         <SettingBtn
           label="음성"
-          description="COMMING SOON!"
+          description="COMING SOON!"
           selected={selectedMethod === "음성"}
           onClick={() => setSelectedMethod("음성")}
+          disabled={true}
         />
         <SettingBtn
           label="영상"
-          description="COMMING SOON!"
+          description="COMING SOON!"
           selected={selectedMethod === "영상"}
           onClick={() => setSelectedMethod("영상")}
+          disabled={true}
         />
       </div>
 

--- a/src/components/interview/step/method-step.tsx
+++ b/src/components/interview/step/method-step.tsx
@@ -1,14 +1,33 @@
-import React from "react";
+import { useState } from "react";
 import NavButtons from "./nav-button";
+import SettingBtn from "@/components/settingbtn";
 
 const MethodStep = ({ onPrev, onNext }: StepProps) => {
+  const [selectedMethod, setSelectedMethod] = useState("채팅");
+
   return (
     <>
-      <div>
-        <button>채팅</button>
-        <button>음성</button>
-        <button>비디오</button>
+      <div className="flex gap-8 justify-center mb-8 max-w-4xl mx-auto">
+        <SettingBtn
+          label="채팅"
+          description="텍스트 기반의 채팅 면접을 진행합니다."
+          selected={selectedMethod === "채팅"}
+          onClick={() => setSelectedMethod("채팅")}
+        />
+        <SettingBtn
+          label="음성"
+          description="COMMING SOON!"
+          selected={selectedMethod === "음성"}
+          onClick={() => setSelectedMethod("음성")}
+        />
+        <SettingBtn
+          label="영상"
+          description="COMMING SOON!"
+          selected={selectedMethod === "영상"}
+          onClick={() => setSelectedMethod("영상")}
+        />
       </div>
+
       <NavButtons
         onPrev={onPrev}
         onNext={onNext}

--- a/src/components/interview/step/type-step.tsx
+++ b/src/components/interview/step/type-step.tsx
@@ -1,13 +1,27 @@
-import React from "react";
+import { useState } from "react";
 import NavButtons from "./nav-button";
+import SettingBtn from "@/components/settingbtn";
 
 const TypeStep = ({ onPrev, onNext }: StepProps) => {
+  const [selectedType, setSelectedType] = useState("Tech");
+
   return (
     <>
-      <div>
-        <button>기술면접</button>
-        <button>인성면접</button>
+      <div className="flex gap-16 justify-center">
+        <SettingBtn
+          label="기술면접"
+          description="관심 직무를 기반으로 기술적 지식, 문제 해결 능력, 실무 적용 역량을 평가하는 면접"
+          selected={selectedType === "Tech"}
+          onClick={() => setSelectedType("Tech")}
+        />
+        <SettingBtn
+          label="인성면접"
+          description="지원자의 성격, 가치관, 대인관계 능력 등을 질문을 통해 직접 확인하고 평가하는 면접"
+          selected={selectedType === "Soft"}
+          onClick={() => setSelectedType("Soft")}
+        />
       </div>
+
       <NavButtons
         onPrev={onPrev}
         onNext={onNext}

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -6,9 +6,16 @@ type ButtonProps = {
   description: string;
   selected: boolean;
   onClick: () => void;
+  disabled?: boolean;
 };
 
-const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
+const SettingBtn = ({
+  label,
+  description,
+  selected,
+  onClick,
+  disabled = false,
+}: ButtonProps) => {
   const [isHovered, setIsHovered] = useState(false);
   const descriptionWords = description.split(" ");
 
@@ -16,10 +23,10 @@ const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
     <div
       className={`relative border rounded-3xl w-[400px] h-[300px] flex items-center justify-center text-center cursor-pointer transition-all duration-300 ${
         selected ? "bg-primary text-white" : "bg-gray-200 text-black"
-      }`}
-      onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+      onClick={!disabled ? onClick : undefined}
+      onMouseEnter={() => !disabled && setIsHovered(true)}
+      onMouseLeave={() => !disabled && setIsHovered(false)}
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
@@ -31,7 +38,11 @@ const SettingBtn = ({ label, description, selected, onClick }: ButtonProps) => {
 
       <div
         className={`absolute bottom-6 text-base font-medium text-black bg-white bg-opacity-90 p-5 rounded-lg shadow-lg transition-all duration-500 transform ${
-          isHovered ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+          disabled
+            ? "opacity-100 translate-y-0"
+            : isHovered
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 translate-y-4"
         }`}
         style={{ width: "90%", minHeight: "4rem" }}
       >


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- feature/DV-60-interview-setup-page

## 📚 작업한 내용
- 면접 유형/방식/입력정보확인 페이지 UI를 구현하였습니다.
- 면접 방식 선택 페이지에서는 음성과 영상은 선택되지 않도록 했습니다.

## 📍 참고 사항
api 연동 전이라서 입력정보확인 페이지에 내용이 연결되어있지 않습니다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/47c6e0f1-4775-41c5-b122-53572891cfcb)
![image](https://github.com/user-attachments/assets/b4cd3922-1215-40f0-ab19-2dd680eb9850)
![image](https://github.com/user-attachments/assets/57f7628f-69e8-4137-8a77-d6674e2fce0e)
![image](https://github.com/user-attachments/assets/e6ff869c-2e5d-4c6d-9a0f-5ddac583fbdc)

