### PR TITLE
[DV-65] 세팅버튼 디자인 수정

### DIFF
--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -27,22 +27,32 @@ const InterviewPage = () => {
         />
       </div>
 
-      <div className="flex gap-4 mt-8 font-semibold">
+      <div className="flex gap-4 mt-8 font-semibold relative">
         <Link href="/">
           <button className="bg-secondary w-24 text-white py-2 px-6 rounded-md">
             홈으로
           </button>
         </Link>
-        <Link href={mode ? `/interview/setup?type=${mode}` : "#"}>
-          <button
-            className={`w-24 py-2 px-6 rounded-md text-white ${
-              mode ? "bg-secondary" : "bg-gray-400 cursor-not-allowed"
-            }`}
-            disabled={!mode}
-          >
-            다음
-          </button>
-        </Link>
+        <div className="relative group">
+          <Link href={mode ? `/interview/setup?type=${mode}` : "#"}>
+            <button
+              className={`w-24 py-2 px-6 rounded-md text-white ${
+                mode ? "bg-secondary" : "bg-gray-400 cursor-not-allowed"
+              }`}
+              disabled={!mode}
+            >
+              다음
+            </button>
+          </Link>
+          {!mode && (
+            <div
+              className="absolute invisible group-hover:visible -top-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-gray-200 text-gray-700 text-sm rounded-md shadow-md z-10"
+              style={{ whiteSpace: "nowrap" }}
+            >
+              버튼을 클릭해주세요
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import SettingBtn from "@/components/settingbtn";
 
 const InterviewPage = () => {
-  const [mode, setMode] = useState("mock");
+  const [mode, setMode] = useState<string | null>(null);
 
   return (
     <div className="flex flex-col items-center gap-6">
@@ -33,8 +33,13 @@ const InterviewPage = () => {
             홈으로
           </button>
         </Link>
-        <Link href={`/interview/setup?type=${mode}`}>
-          <button className="bg-secondary w-24 text-white py-2 px-6 rounded-md">
+        <Link href={mode ? `/interview/setup?type=${mode}` : "#"}>
+          <button
+            className={`w-24 py-2 px-6 rounded-md text-white ${
+              mode ? "bg-secondary" : "bg-gray-400 cursor-not-allowed"
+            }`}
+            disabled={!mode}
+          >
             다음
           </button>
         </Link>

--- a/src/components/interview/step/job-step.tsx
+++ b/src/components/interview/step/job-step.tsx
@@ -30,6 +30,7 @@ const JobStep = ({ onPrev, onNext }: StepProps) => {
         onNext={onNext}
         prevButtonText="이전"
         nextButtonText="다음"
+        disabled={!selectedJob}
       />
     </>
   );

--- a/src/components/interview/step/nav-button.tsx
+++ b/src/components/interview/step/nav-button.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
-interface NavButtonsProps extends StepProps {
-  prevButtonText: string;
-  nextButtonText: string;
+interface NavButtonsProps extends StepProps, ButtonsProps {
+  disabled?: boolean;
 }
 
 const NavButtons = ({
@@ -10,9 +9,10 @@ const NavButtons = ({
   onNext,
   prevButtonText,
   nextButtonText,
+  disabled = false,
 }: NavButtonsProps) => {
   return (
-    <div className="flex gap-4 mt-8 font-semibold">
+    <div className="flex gap-4 mt-8 font-semibold justify-center">
       <button
         onClick={onPrev}
         className="bg-secondary w-24 text-white py-2 px-6 rounded-md"
@@ -20,8 +20,11 @@ const NavButtons = ({
         {prevButtonText}
       </button>
       <button
-        onClick={onNext}
-        className="bg-secondary w-24 text-white py-2 px-6 rounded-md"
+        onClick={!disabled ? onNext : undefined}
+        className={`w-24 py-2 px-6 rounded-md text-white ${
+          disabled ? "bg-gray-400 cursor-not-allowed" : "bg-secondary"
+        }`}
+        disabled={disabled}
       >
         {nextButtonText}
       </button>

--- a/src/components/interview/step/nav-button.tsx
+++ b/src/components/interview/step/nav-button.tsx
@@ -12,22 +12,32 @@ const NavButtons = ({
   disabled = false,
 }: NavButtonsProps) => {
   return (
-    <div className="flex gap-4 mt-8 font-semibold justify-center">
+    <div className="flex gap-4 mt-8 font-semibold justify-center relative">
       <button
         onClick={onPrev}
         className="bg-secondary w-24 text-white py-2 px-6 rounded-md"
       >
         {prevButtonText}
       </button>
-      <button
-        onClick={!disabled ? onNext : undefined}
-        className={`w-24 py-2 px-6 rounded-md text-white ${
-          disabled ? "bg-gray-400 cursor-not-allowed" : "bg-secondary"
-        }`}
-        disabled={disabled}
-      >
-        {nextButtonText}
-      </button>
+      <div className="relative group">
+        <button
+          onClick={!disabled ? onNext : undefined}
+          className={`w-24 py-2 px-6 rounded-md text-white ${
+            disabled ? "bg-gray-400 cursor-not-allowed" : "bg-secondary"
+          }`}
+          disabled={disabled}
+        >
+          {nextButtonText}
+        </button>
+        {disabled && (
+          <div
+            className="absolute invisible group-hover:visible -top-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-gray-200 text-gray-700 text-sm rounded-md shadow-md z-10"
+            style={{ whiteSpace: "nowrap" }}
+          >
+            버튼을 클릭해주세요
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/interview/step/type-step.tsx
+++ b/src/components/interview/step/type-step.tsx
@@ -3,7 +3,7 @@ import NavButtons from "./nav-button";
 import SettingBtn from "@/components/settingbtn";
 
 const TypeStep = ({ onPrev, onNext }: StepProps) => {
-  const [selectedType, setSelectedType] = useState("Tech");
+  const [selectedType, setSelectedType] = useState<string | null>(null);
 
   return (
     <>
@@ -27,6 +27,7 @@ const TypeStep = ({ onPrev, onNext }: StepProps) => {
         onNext={onNext}
         prevButtonText="이전"
         nextButtonText="다음"
+        disabled={!selectedType}
       />
     </>
   );

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -22,7 +22,9 @@ const SettingBtn = ({
   return (
     <div
       className={`relative border rounded-3xl w-[400px] h-[300px] flex items-center justify-center text-center cursor-pointer transition-all duration-300 ${
-        selected ? "bg-primary text-white" : "bg-gray-200 text-black"
+        selected || isHovered
+          ? "bg-primary text-white"
+          : "bg-gray-200 text-black"
       } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
       onClick={!disabled ? onClick : undefined}
       onMouseEnter={() => !disabled && setIsHovered(true)}
@@ -30,7 +32,7 @@ const SettingBtn = ({
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
-          isHovered ? "-translate-y-2" : ""
+          isHovered && !selected ? "-translate-y-2" : ""
         }`}
       >
         {label}
@@ -38,9 +40,7 @@ const SettingBtn = ({
 
       <div
         className={`absolute bottom-6 text-base font-medium text-black bg-white bg-opacity-90 p-5 rounded-lg shadow-lg transition-all duration-500 transform ${
-          disabled
-            ? "opacity-100 translate-y-0"
-            : isHovered
+          selected || (isHovered && !disabled)
             ? "opacity-100 translate-y-0"
             : "opacity-0 translate-y-4"
         }`}

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -21,30 +21,36 @@ const SettingBtn = ({
 
   return (
     <div
-      className={`relative border rounded-3xl w-[400px] h-[300px] flex items-center justify-center text-center cursor-pointer transition-all duration-300 ${
-        selected || isHovered
+      className={`relative border rounded-3xl w-[400px] h-[300px] flex items-center justify-center text-center transition-all duration-300 ${
+        selected
           ? "bg-primary text-white"
+          : disabled
+          ? "bg-gray-300 text-gray-500"
           : "bg-gray-200 text-black"
-      } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+      } ${disabled ? "opacity-60" : ""} ${!disabled ? "cursor-pointer" : ""}`}
       onClick={!disabled ? onClick : undefined}
-      onMouseEnter={() => !disabled && setIsHovered(true)}
-      onMouseLeave={() => !disabled && setIsHovered(false)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
-          isHovered && !selected ? "-translate-y-2" : ""
+          isHovered && !disabled ? "-translate-y-2" : ""
         }`}
       >
         {label}
       </div>
 
       <div
-        className={`absolute bottom-6 text-base font-medium text-black bg-white bg-opacity-90 p-5 rounded-lg shadow-lg transition-all duration-500 transform ${
-          selected || (isHovered && !disabled)
+        className={`absolute bottom-6 text-base font-medium bg-white bg-opacity-90 p-5 rounded-lg shadow-lg transition-all duration-500 transform ${
+          disabled || selected || (isHovered && !disabled)
             ? "opacity-100 translate-y-0"
             : "opacity-0 translate-y-4"
         }`}
-        style={{ width: "90%", minHeight: "4rem" }}
+        style={{
+          width: "90%",
+          minHeight: "4rem",
+          color: disabled ? "gray" : "black",
+        }}
       >
         {descriptionWords.map((word, index) => (
           <span key={index} className="inline-block mr-1">
@@ -52,6 +58,12 @@ const SettingBtn = ({
           </span>
         ))}
       </div>
+
+      {disabled && isHovered && (
+        <div className="absolute inset-0 bg-gray-500 bg-opacity-40 flex items-center justify-center text-black font-bold text-lg rounded-3xl">
+          아직 사용할 수 없습니다.
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -25,12 +25,14 @@ const SettingBtn = ({
         selected
           ? "bg-primary text-white"
           : disabled
-          ? "bg-gray-300 text-gray-500"
-          : "bg-gray-200 text-black"
-      } ${disabled ? "opacity-60" : ""} ${!disabled ? "cursor-pointer" : ""}`}
+          ? "bg-gray-300 text-gray-500 opacity-60 cursor-not-allowed"
+          : isHovered
+          ? "bg-primary text-white cursor-pointer"
+          : "bg-gray-200 text-black cursor-pointer"
+      }`}
       onClick={!disabled ? onClick : undefined}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={() => !disabled && setIsHovered(true)}
+      onMouseLeave={() => !disabled && setIsHovered(false)}
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
@@ -58,12 +60,6 @@ const SettingBtn = ({
           </span>
         ))}
       </div>
-
-      {disabled && isHovered && (
-        <div className="absolute inset-0 bg-gray-500 bg-opacity-40 flex items-center justify-center text-black font-bold text-lg rounded-3xl">
-          아직 사용할 수 없습니다.
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- feature/DV-65-refactor-setting-btn

## 📚 작업한 내용

- 페이지 진입 시 아무것도 선택되어 있지 않은 상태로 변경하였습니다.
- settingbtn에 마우스 호버 시 primary 배경 색으로 변경되며 설명이 뜨도록 하였습니다.
- settingbtn 선택 시 설명이 보여지는 상태로 유지하도록 하였습니다.
- 아무것도 선택되지 않았을 때 다음버튼이 회색으로 비활성화되며 마우스를 올렸을 때 "버튼을 클릭해주세요." 라는 툴팁이 보이도록 하였습니다.


## 📸 스크린샷
- 페이지 처음 모습 : 아무것도 선택되지 않은 상태로 보여집니다.
![image](https://github.com/user-attachments/assets/436505f4-93d4-4b53-a86d-02dda61d6bd7)
- 버튼 클릭 시: 설명 부분이 보여지는 상태로 유지되며 다음 버튼도 활성화되어 있습니다.
![image](https://github.com/user-attachments/assets/1a4b74ec-c570-462e-97b1-0bb043c8b660)
- 다음 버튼 툴팁 : 아무것도 선택되지 않은 상태로 마우스 호버 시 안내창을 보여줍니다.
![image](https://github.com/user-attachments/assets/1c1290e6-ab19-45a2-82ec-90a0238ac841)

