### PR TITLE
[DV-158] 디자인 수정 및 자료입력 컴포넌트 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.7",
         "chart.js": "^4.4.6",
         "framer-motion": "^11.11.11",
+        "mammoth": "^1.8.0",
         "next": "15.0.1",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
@@ -20,7 +21,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
         "react-toastify": "^10.0.6",
-        "uuid": "^11.0.2",
+        "uuid": "^11.0.3",
         "zustand": "^5.0.1"
       },
       "devDependencies": {
@@ -2636,6 +2637,14 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2947,6 +2956,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2958,6 +2986,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -3196,6 +3229,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
@@ -3365,6 +3403,11 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -3381,6 +3424,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4531,6 +4582,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4570,8 +4626,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -5086,6 +5141,17 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5124,6 +5190,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -5173,11 +5247,52 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/mammoth": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.8.0.tgz",
+      "integrity": "sha512-pJNfxSk9IEGVpau+tsZFz22ofjUsl2mnA5eT8PjPs2n0BP+rhVte4Nez6FdgEuxv3IGI3afiV46ImKqTGDVlbA==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.1",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5508,6 +5623,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5561,6 +5681,11 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5586,7 +5711,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5830,6 +5954,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5949,6 +6078,25 @@
       "dependencies": {
         "pify": "^2.3.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6103,6 +6251,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -6171,6 +6324,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -6279,12 +6437,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -6859,6 +7030,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -6877,13 +7053,12 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
-      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7094,6 +7269,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/yaml": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.7",
     "chart.js": "^4.4.6",
     "framer-motion": "^11.11.11",
+    "mammoth": "^1.8.0",
     "next": "15.0.1",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
@@ -21,7 +22,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-toastify": "^10.0.6",
-    "uuid": "^11.0.2",
+    "uuid": "^11.0.3",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -5,7 +5,7 @@ import SettingBtn from "@/components/settingbtn";
 import useInterviewStore, { InterviewMode } from "@/stores/useInterviewStore";
 
 const InterviewPage = () => {
-  const [mode, setMode] = useState<InterviewMode>();
+  const [mode, setMode] = useState<InterviewMode>("REAL");
   const { updateInterviewField } = useInterviewStore();
 
   const handleClick = () => {
@@ -26,6 +26,7 @@ const InterviewPage = () => {
           description="선택한 관심 직무를 기반으로 가상면접을 진행합니다."
           selected={mode === "GENERAL"}
           onClick={() => setMode("GENERAL")}
+          disabled={true}
         />
         <SettingBtn
           label="실전면접"
@@ -42,25 +43,26 @@ const InterviewPage = () => {
           </button>
         </Link>
         <div className="relative group">
-          <Link href={mode ? `/interview/setup?type=${mode}` : "#"}>
+          <Link href={`/interview/setup?type=${mode}`}>
             <button
-              className={`w-24 py-2 px-6 rounded-md text-white ${
-                mode ? "bg-secondary" : "bg-gray-400 cursor-not-allowed"
-              }`}
-              disabled={!mode}
+              className="bg-secondary w-24 py-2 px-6 rounded-md text-white"
+              // className={`w-24 py-2 px-6 rounded-md text-white ${
+              //   mode ? "bg-secondary" : "bg-gray-400 cursor-not-allowed"
+              // }`}
+              // disabled={!mode}
               onClick={handleClick}
             >
               다음
             </button>
           </Link>
-          {!mode && (
+          {/* {!mode && (
             <div
               className="absolute invisible group-hover:visible -top-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-gray-200 text-gray-700 text-sm rounded-md shadow-md z-10"
               style={{ whiteSpace: "nowrap" }}
             >
               버튼을 클릭해주세요
             </div>
-          )}
+          )} */}
         </div>
       </div>
     </div>

--- a/src/components/interview/step/cover-letter-step.tsx
+++ b/src/components/interview/step/cover-letter-step.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { FILES } from "@/data/profileData";
 import MultiFileUploadPanel from "@/components/multi-file-upload-panel";
 import useInterviewStore from "@/stores/useInterviewStore";
@@ -6,9 +7,11 @@ import NavButtons from "./nav-button";
 
 const CoverLetterStep = ({ onPrev, onNext }: StepProps) => {
   const { updateInterviewField } = useInterviewStore();
+  const [isFileSelected, setIsFileSelected] = useState(false);
 
   const handleSubmit = (files: string[]) => {
     updateInterviewField("files", files);
+    setIsFileSelected(files.length > 0);
   };
 
   return (
@@ -20,6 +23,8 @@ const CoverLetterStep = ({ onPrev, onNext }: StepProps) => {
         onNext={onNext}
         prevButtonText="이전"
         nextButtonText="다음"
+        disabled={!isFileSelected}
+        tooltipMessage="자료를 입력해주세요"
       />
     </>
   );

--- a/src/components/interview/step/cover-letter-step.tsx
+++ b/src/components/interview/step/cover-letter-step.tsx
@@ -2,30 +2,24 @@
 import { FILES } from "@/data/profileData";
 import MultiFileUploadPanel from "@/components/multi-file-upload-panel";
 import useInterviewStore from "@/stores/useInterviewStore";
+import NavButtons from "./nav-button";
 
 const CoverLetterStep = ({ onPrev, onNext }: StepProps) => {
   const { updateInterviewField } = useInterviewStore();
 
   const handleSubmit = (files: string[]) => {
-    onNext();
     updateInterviewField("files", files);
-  };
-
-  const handleBackClick = () => {
-    if (onPrev) {
-      onPrev();
-    }
   };
 
   return (
     <>
-      <MultiFileUploadPanel
-        files={FILES}
-        submitButtonText="다음"
-        submitButtonColor="bg-[#fabe41]"
-        showBackButton
-        onSubmitButtonClick={handleSubmit}
-        onBackButtonClick={handleBackClick}
+      <MultiFileUploadPanel files={FILES} onSubmitButtonClick={handleSubmit} />
+
+      <NavButtons
+        onPrev={onPrev}
+        onNext={onNext}
+        prevButtonText="이전"
+        nextButtonText="다음"
       />
     </>
   );

--- a/src/components/interview/step/nav-button.tsx
+++ b/src/components/interview/step/nav-button.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 interface NavButtonsProps extends StepProps, ButtonsProps {
   disabled?: boolean;
+  tooltipMessage?: string;
 }
 
 const NavButtons = ({
@@ -10,6 +11,7 @@ const NavButtons = ({
   prevButtonText,
   nextButtonText,
   disabled = false,
+  tooltipMessage = "버튼을 클릭해주세요",
 }: NavButtonsProps) => {
   return (
     <div className="flex gap-4 mt-8 font-semibold justify-center relative">
@@ -34,7 +36,7 @@ const NavButtons = ({
             className="absolute invisible group-hover:visible -top-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-gray-200 text-gray-700 text-sm rounded-md shadow-md z-10"
             style={{ whiteSpace: "nowrap" }}
           >
-            버튼을 클릭해주세요
+            {tooltipMessage}
           </div>
         )}
       </div>

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -185,12 +185,25 @@ const MultiFileUploadPanel = ({
     }
 
     if (isManualInput) {
-      toast.success(`${activeTab}에 텍스트가 저장되었습니다.`);
+      const fileName = `자기소개서-${new Date()
+        .toISOString()
+        .slice(0, 10)}.txt`;
+      const textBlob = new Blob([manualText], { type: "text/plain" });
+      const textFile = new File([textBlob], fileName);
+
+      setFileList((prev) => [
+        ...prev,
+        { id: uuidv4(), name: fileName, type: activeTab },
+      ]);
+
+      await handleUpload(textFile);
+
+      toast.success(`${activeTab}에 텍스트 파일이 저장되었습니다.`);
     } else {
       const newFile = { id: uuidv4(), name: selectedFile!, type: activeTab };
       setFileList((prev) => [...prev, newFile]);
       toast.success(`${activeTab}에 파일이 저장되었습니다.`);
-      await handleUpload();
+      await handleUpload(file!);
     }
 
     setSelectedFile(null);
@@ -209,8 +222,8 @@ const MultiFileUploadPanel = ({
     }
   };
 
-  const handleUpload = async () => {
-    if (!file) {
+  const handleUpload = async (uploadFile: File) => {
+    if (!uploadFile) {
       toast.error("파일이 선택되지 않았습니다.");
       return;
     }
@@ -222,8 +235,8 @@ const MultiFileUploadPanel = ({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          fileName: `cover-letters/${file.name}`,
-          fileType: file.type,
+          fileName: `cover-letters/${uploadFile.name}`,
+          fileType: uploadFile.type,
         }),
       });
 
@@ -235,8 +248,8 @@ const MultiFileUploadPanel = ({
 
       await fetch(presignedUrl, {
         method: "PUT",
-        headers: { "Content-Type": file.type },
-        body: file,
+        headers: { "Content-Type": uploadFile.type },
+        body: uploadFile,
       });
 
       toast.success("파일이 성공적으로 업로드되었습니다.");

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -58,8 +58,10 @@ const MultiFileUploadPanel = ({
   const [file, setFile] = useState<File | null>(null);
   const [isManualInput, setIsManualInput] = useState<boolean>(false);
   const [manualText, setManualText] = useState<string>("");
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const [modalMessage, setModalMessage] = useState<string>("");
+  const [modalState, setModalState] = useState({
+    show: false,
+    message: "",
+  });
   const [pendingFile, setPendingFile] = useState<File | null>(null);
 
   const handleTabChange = (tab: string) => {
@@ -83,10 +85,10 @@ const MultiFileUploadPanel = ({
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (isManualInput) {
-      setModalMessage(
-        "현재 입력 중인 내용이 사라집니다. 파일을 선택하시겠습니까?"
-      );
-      setShowModal(true);
+      setModalState({
+        show: true,
+        message: "현재 입력 중인 내용이 사라집니다. 파일을 선택하시겠습니까?",
+      });
       setPendingFile(file || null);
     } else if (file) {
       processFile(file);
@@ -110,10 +112,10 @@ const MultiFileUploadPanel = ({
 
   const handleManualInput = () => {
     if (selectedFile) {
-      setModalMessage(
-        "현재 선택된 파일이 해제됩니다. 직접 입력을 진행하시겠습니까?"
-      );
-      setShowModal(true);
+      setModalState({
+        show: true,
+        message: "현재 선택된 파일이 해제됩니다. 직접 입력을 진행하시겠습니까?",
+      });
     } else {
       setIsManualInput(true);
       setPdfUrl(null);
@@ -122,7 +124,7 @@ const MultiFileUploadPanel = ({
   };
 
   const handleModalConfirm = () => {
-    setShowModal(false);
+    setModalState({ show: false, message: "" });
     if (pendingFile) {
       processFile(pendingFile);
       setPendingFile(null);
@@ -134,7 +136,7 @@ const MultiFileUploadPanel = ({
   };
 
   const handleModalCancel = () => {
-    setShowModal(false);
+    setModalState({ show: false, message: "" });
     setPendingFile(null);
   };
 
@@ -218,9 +220,9 @@ const MultiFileUploadPanel = ({
 
   return (
     <div className="flex flex-col items-center">
-      {showModal && (
+      {modalState.show && (
         <Modal
-          message={modalMessage}
+          message={modalState.message}
           onConfirm={handleModalConfirm}
           onCancel={handleModalCancel}
         />

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -184,7 +184,7 @@ const MultiFileUploadPanel = ({
               type="file"
               onChange={handleFileChange}
               className="hidden"
-              accept="application/txt"
+              accept=".pdf,.docx,.txt,.md"
               onClick={(e) => {
                 e.currentTarget.value = "";
               }}

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -175,7 +175,10 @@ const MultiFileUploadPanel = ({
   };
 
   const handleUpload = async () => {
-    if (!file) return alert("파일을 선택하세요.");
+    if (!file) {
+      toast.error("파일이 선택되지 않았습니다.");
+      return;
+    }
 
     setUploading(true);
 
@@ -190,7 +193,7 @@ const MultiFileUploadPanel = ({
       });
 
       if (!response.ok) {
-        throw new Error("Failed to get presigned URL");
+        throw new Error("서버에서 URL을 가져오지 못했습니다.");
       }
 
       const { presignedUrl } = await response.json();
@@ -200,9 +203,14 @@ const MultiFileUploadPanel = ({
         headers: { "Content-Type": file.type },
         body: file,
       });
-    } catch (error) {
-      console.error("Upload error:", error);
-      alert("파일 업로드에 실패했습니다.");
+
+      toast.success("파일이 성공적으로 업로드되었습니다.");
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(`업로드 실패: ${error.message}`);
+      } else {
+        toast.error("업로드 중 알 수 없는 오류가 발생했습니다.");
+      }
     } finally {
       setUploading(false);
     }

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -223,6 +223,11 @@ const MultiFileUploadPanel = ({
           </p>
         )}
       </div>
+      {selectedFile && (
+        <div className="mt-2 text-gray-500 font-medium">
+          파일명: {selectedFile}
+        </div>
+      )}
       <ToastContainer
         position="bottom-right"
         toastStyle={{ fontWeight: "500" }}

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -184,6 +184,8 @@ const MultiFileUploadPanel = ({
       return;
     }
 
+    let savedFileName = "";
+
     if (isManualInput) {
       const fileName = `자기소개서-${new Date()
         .toISOString()
@@ -198,12 +200,18 @@ const MultiFileUploadPanel = ({
 
       await handleUpload(textFile);
 
+      savedFileName = fileName;
       toast.success(`${activeTab}에 텍스트 파일이 저장되었습니다.`);
     } else {
       const newFile = { id: uuidv4(), name: selectedFile!, type: activeTab };
       setFileList((prev) => [...prev, newFile]);
+      savedFileName = selectedFile!;
       toast.success(`${activeTab}에 파일이 저장되었습니다.`);
       await handleUpload(file!);
+    }
+
+    if (onSubmitButtonClick) {
+      onSubmitButtonClick([`cover-letters/${savedFileName}`]);
     }
 
     setSelectedFile(null);

--- a/src/components/multi-file-upload-panel.tsx
+++ b/src/components/multi-file-upload-panel.tsx
@@ -209,7 +209,7 @@ const MultiFileUploadPanel = ({
   };
 
   return (
-    <div className="flex flex-col items-center p-8 min-h-screen">
+    <div className="flex flex-col items-center">
       {showModal && (
         <Modal
           message={modalMessage}

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -36,7 +36,7 @@ const SettingBtn = ({
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
-          isHovered && !disabled ? "-translate-y-2" : ""
+          isHovered && !disabled ? "-translate-y-12" : ""
         }`}
       >
         {label}

--- a/src/components/settingbtn.tsx
+++ b/src/components/settingbtn.tsx
@@ -36,7 +36,7 @@ const SettingBtn = ({
     >
       <div
         className={`font-bold text-4xl tracking-widest transition-transform duration-300 ${
-          isHovered && !disabled ? "-translate-y-12" : ""
+          selected || (isHovered && !disabled) ? "-translate-y-12" : ""
         }`}
       >
         {label}

--- a/src/data/profileData.ts
+++ b/src/data/profileData.ts
@@ -1,10 +1,9 @@
 export interface MultiFileUploadPanelDataType {
   name: string;
-  type: "coverLetter" | "resume" | "portfolio";
+  type: "coverLetter" | "resume";
 }
 
 export const FILES: MultiFileUploadPanelDataType[] = [
   { type: "coverLetter", name: "자기소개서" },
   { type: "resume", name: "이력서" },
-  { type: "portfolio", name: "포트폴리오" },
 ];


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치

- feature/DV-158-design-refactoring

## 📚 작업한 내용
1. 디자인 수정
- 면접 setup 버튼 호버시 label 높이 올리기
- 선택된 버튼은 label이 그 위치에 고정되도록 하기
- 모의면접 기능 막기
2. 자료 입력 컴포넌트 기능 추가
- 포트폴리오 버튼 제거
- 자기소개서선택 -> 입력정보확인으로 넘어가는 단계에 이전 다음 버튼 통일감이 없어서 저장 버튼을 상단으로 올림
- 직접입력 기능 추가
- 직접입력 <-> 파일선택 오갈때 앞서 선택한 자료가 없어진다는 경고모달 추가
- 파일은 .pdf, .docx, .txt, .md 만 입력 가능하도록 하기
- .docx 파일 선택시 미리보기 공간에 텍스트만 추출되어 볼 수 있도록 하기
- 직접입력하고 저장 버튼을 눌렀을 때 .txt 파일로 변환되어 S3에 저장되도록 하기

## 📍 참고 사항
- 직접입력하고 저장한 파일명은 자기소개서-[년]-[월]-[일].txt 로 저장되도록 하였습니다. 이 부분은 추후 API 연동하며 생성해준 파일명으로 변경하도록 하겠습니다.
- docx는 미리보기로 볼 수 있는 방법이 없어서 pdf로 변환 후 보여질 수 있도록 하였습니다. 이 과정에서 이미지와 도표 같은 요소는 처리가 안되어서 미리보기 공간에 가독성이 조금 떨어집니다. 우선 docx 파일을 미리볼 수 있는 방법이 없어 처리를 해두었지만 더 좋은 방법이 있으면 변경해도 좋습니다.

## 📸 스크린샷
1. 디자인 수정
- 모의면접 막기
![image](https://github.com/user-attachments/assets/8ff0556a-2faa-43ea-81f4-e19a308f909e)
- 호버 & 선택 시 label 위치 조정 
![image](https://github.com/user-attachments/assets/1c826c24-382f-4bcd-9477-19d9da37d790)

2. 자료 입력 컴포넌트 기능 추가
- 이전&다음 버튼과의 기능 분리로 구성 수정 (포트폴리오 버튼도 제거함)
![image](https://github.com/user-attachments/assets/3a245a39-2d73-46d0-bbaa-8f70e9353658)
- 직접 입력 기능 추가
![image](https://github.com/user-attachments/assets/f5fd1c2c-22d0-43d5-bb2e-32f79515d86e)
- 입력 중인 내용이 있을 때 파일선택하는 상황 파일이 선택되어 있는 상황에서 직접입력 버튼 클릭시 경고모달
![image](https://github.com/user-attachments/assets/f55e5921-1697-4c5c-95f6-9a3b9238c10e)
![image](https://github.com/user-attachments/assets/f5d11542-dbcf-48e4-8031-c5701ac44e0e)
- 직접입력 후 저장하면 txt 파일로 저장
![image](https://github.com/user-attachments/assets/fca8a677-fa4b-4684-b9a4-401cfb575e47)
![image](https://github.com/user-attachments/assets/8f65ed73-50ca-48ff-970a-5a6f1aeffaec)
- .pdf, .docx, .txt, .md 제외한 파일은 선택 안되도록 막기
![image](https://github.com/user-attachments/assets/4942875e-a92c-489f-bd92-72239eeb660d)
- docx 파일 선택 시 텍스트만 추출하여 미리보기 공간에 보여주기
![image](https://github.com/user-attachments/assets/67c2ffa6-f2ce-4b01-a8d4-be8a4a4c08f4)
